### PR TITLE
Fix Logging Code

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -32,7 +32,7 @@ void BASE_LOG(enum log_level level, const char *fmt, ...)
   if (g_options.log_destination == LOGGING_STDERR)
     vfprintf(stderr, fmt, arg);
   else if (g_options.log_destination == LOGGING_SYSLOG)
-    syslog(LOG_ERR, fmt, arg);
+    vsyslog(LOG_ERR, fmt, arg);
   va_end(arg);
 }
 

--- a/systemd-udev/55-ippusbxd.rules
+++ b/systemd-udev/55-ippusbxd.rules
@@ -1,3 +1,3 @@
 # ippusbxd udev rules file
 
-ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device" ENV{ID_USB_INTERFACES}=="*:070104:*", OWNER="root", GROUP="lp", MODE="0664", PROGRAM="/bin/systemd-escape --template=ippusbxd@.service $env{BUSNUM}:$env{DEVNUM}", ENV{SYSTEMD_WANTS}+="%c"
+ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device" ENV{ID_USB_INTERFACES}=="*:070104:*", OWNER="root", GROUP="lp", MODE="0664", TAG+="systemd", PROGRAM="/bin/systemd-escape --template=ippusbxd@.service $env{BUSNUM}:$env{DEVNUM}", ENV{SYSTEMD_WANTS}+="%c"


### PR DESCRIPTION
Changing logging code to use the "vsyslog()" version of the function. As the old code was passing a vector of arguments which was resulting in a segmentation fault.