### PR TITLE
Formating dnssd to match style of codebase and add header comments

### DIFF
--- a/src/dnssd.h
+++ b/src/dnssd.h
@@ -25,7 +25,15 @@ typedef struct dnssd_s {
   AvahiEntryGroup   *ipp_ref;
 } dnssd_t;
 
+/* Initializes DNS-SD broadcasting. Returns 0 on success and a non-zero value if
+   there is a failure. */
 int dnssd_init();
+
+/* Shutdown DNS-SD broadcasting. */
 void dnssd_shutdown();
-int dnssd_register();
+
+/* Register a printer object via DNS-SD. */
+int dnssd_register(AvahiClient *c);
+
+/* Unregister a printer object from DNS-SD. */
 void dnssd_unregister();


### PR DESCRIPTION
This change re-formats some of the code in dnssd.c to fit under 80
characters in width and match the function definition style used in the
rest of the code. This change also adds brief header comments to the
functions declared in dnssd.h.