### PR TITLE
Add entry _uscan._tcp

### DIFF
--- a/src/dnssd.c
+++ b/src/dnssd.c
@@ -467,6 +467,8 @@ int dnssd_register(AvahiClient *c)
 
   avahi_string_list_free(ipp_txt);
 
+  if (g_options.scanner_present == 1)
+     goto noscanner;
  /*
   * Create the TXT record for scanner ...
   */
@@ -524,7 +526,7 @@ int dnssd_register(AvahiClient *c)
   avahi_entry_group_commit(g_options.dnssd_data->uscan_ref);
 
   avahi_string_list_free(uscan_txt);
-
+noscanner:
   return 0;
 }
 

--- a/src/dnssd.c
+++ b/src/dnssd.c
@@ -467,7 +467,7 @@ int dnssd_register(AvahiClient *c)
 
   avahi_string_list_free(ipp_txt);
 
-  if (g_options.scanner_present == 1)
+  if (g_options.scanner_present == 0)
      goto noscanner;
  /*
   * Create the TXT record for scanner ...

--- a/src/dnssd.c
+++ b/src/dnssd.c
@@ -481,7 +481,7 @@ int dnssd_register(AvahiClient *c)
   uscan_txt = avahi_string_list_add_printf(uscan_txt, "ty=%s %s", make, model);
   if (strcasecmp(g_options.interface, "lo") == 0)
        uscan_txt = avahi_string_list_add_printf(uscan_txt, "adminurl=%s", temp);
-  uscan_txt = avahi_string_list_add_printf(uscan_txt, "pdl=%s", formats);
+  uscan_txt = avahi_string_list_add_printf(uscan_txt, "pdl=image/jpeg");
   uscan_txt = avahi_string_list_add_printf(uscan_txt, "vers=2.0");
   uscan_txt = avahi_string_list_add_printf(uscan_txt, "txtvers=1");
 

--- a/src/dnssd.h
+++ b/src/dnssd.h
@@ -23,6 +23,7 @@ typedef struct dnssd_s {
   AvahiThreadedPoll *DNSSDMaster;
   AvahiClient       *DNSSDClient;
   AvahiEntryGroup   *ipp_ref;
+  AvahiEntryGroup   *uscan_ref;
 } dnssd_t;
 
 /* Initializes DNS-SD broadcasting. Returns 0 on success and a non-zero value if

--- a/src/options.h
+++ b/src/options.h
@@ -51,6 +51,9 @@ struct options {
   pthread_t usb_event_thread_handle;
   struct tcp_sock_t *tcp_socket;
   struct tcp_sock_t *tcp6_socket;
+
+  /* Scanner presence */
+  int scanner_present;
 };
 
 extern struct options g_options;

--- a/src/usb.c
+++ b/src/usb.c
@@ -31,7 +31,42 @@
 
 #define IGNORE(x) (void)(x)
 
+#define le16_to_cpu(x) libusb_cpu_to_le16(libusb_cpu_to_le16(x))
+
 static int bus, dev_addr;
+
+static int is_ippusb_scanner(const struct libusb_interface_descriptor *interf)
+{
+  unsigned int i;
+  unsigned int n;
+  const unsigned char *buf;
+  unsigned int size;
+
+  if (interf->extra_length) {
+    size = interf->extra_length;
+    buf = interf->extra;
+    while (size >= 2 * sizeof(uint8_t)) {
+      if (buf[0] < 2) {
+        break;
+      }
+
+      if (buf[1] == (LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_DT_INTERFACE)) {
+        if (interf->bInterfaceClass == LIBUSB_CLASS_PRINTER) {
+          n = 4;
+          for (i = 0 ; i < buf[3] ; i++) {
+            if (buf[n] == 0x00) {  /* Basic capabilities */
+              uint16_t caps = le16_to_cpu(*((uint16_t*)&buf[n+2]));
+              if (caps & 0x02)
+                return 1;
+            }
+            n += 2 + buf[n+1];
+          }
+        }
+      }
+    }
+  }
+  return 0;
+}
 
 static int is_ippusb_interface(const struct libusb_interface_descriptor *interf)
 {
@@ -43,6 +78,7 @@ static int is_ippusb_interface(const struct libusb_interface_descriptor *interf)
 static int count_ippoverusb_interfaces(struct libusb_config_descriptor *config)
 {
   int ippusb_interface_count = 0;
+  g_options.scanner_present = 0;
 
   NOTE("Counting IPP-over-USB interfaces ...");
   for (uint8_t interface_num = 0;
@@ -66,12 +102,16 @@ static int count_ippoverusb_interfaces(struct libusb_config_descriptor *config)
       if (!is_ippusb_interface(alt))
 	continue;
 
+      if (g_options.scanner_present == 0)
+          g_options.scanner_present = is_ippusb_scanner(alt);
+
       NOTE("   -> is IPP-over-USB");
       ippusb_interface_count++;
       break;
     }
   }
 
+  NOTE("   -> Scanner present %d", g_options.scanner_present);
   NOTE("   -> %d Interfaces", ippusb_interface_count);
   return ippusb_interface_count;
 }


### PR DESCRIPTION
Since version 1.4 AirPrint, all multifunction devices implement the AirScan. My question is simple (I'm on vacation, I can't test), isn't a modification like this enough?