### PR TITLE
Test tmp before using it with strlen.

### DIFF
--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -216,6 +216,7 @@ char * get_format_paper(char *val)
 	       
 	       if (!tmp) continue;
 	       tmp = strchr(val, '}');
+	       if (!tmp) continue;
 	       a = strlen(val) - strlen(tmp);
 	       strncpy(test2, val, a);
 	       if (strchr(test2, '-') == NULL)


### PR DESCRIPTION
Test tmp before using it with strlen.
this bug causes a crash at Focal startup https://github.com/OpenPrinting/ippusbxd/issues/32