### PR TITLE
Increase HTTP and USB packet size.

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -25,7 +25,7 @@
 #include "http.h"
 #include "logging.h"
 
-#define BUFFER_STEP (1 << 12)
+#define BUFFER_STEP (1 << 15)
 
 struct http_packet_t *packet_new()
 {


### PR DESCRIPTION
Previously, we used a 4KiB packet size for USB transfers and HTTP
packets. This should work fine, but it's slow, especially for large IPP
print and eSCL scan jobs. Therefore, change it to 32KiB to speed things
up a bit.

As a data point, a scan on a virtual test printer was taking 1.8 seconds
with ipp-usb (which uses a 32KiB buffer size), and 8.5 seconds with
ippusbxd's 4 KiB buffer.

This could potentially be increased further; 32 KiB is not necessarily
the point of diminishing returns.

Also open to discussion about whether this is the right value to use, or if we want to add a flag to set this value as well.