### PR TITLE
Put back to original behavior, fix #40.

### DIFF
--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -300,6 +300,7 @@ ipp_request(ippPrinter *printer, int port)
     if (!strcasecmp(attr_name, "printer-icons"))
        printer->representation = strdup(buffer);
     else if (!strcasecmp(attr_name, "printer-device-id")) {
+       char *ptr = NULL;
 //     usb_MDL:          MDL, extracted from "printer-device-id"
 //     usb_MFG:          MFG, extracted from "printer-device-id"
 //     usb_CMD:          CMD, extracted from "printer-device-id"
@@ -307,6 +308,10 @@ ipp_request(ippPrinter *printer, int port)
        printer->mfg = _search_tag(buffer, "MFG:");
        printer->mdl = _search_tag(buffer, "MDL:");
        printer->cmd = _search_tag(buffer, "CMD:");
+        if (((ptr = strcasestr(printer->cmd, "apple")) != NULL &&
+             strcasestr(ptr, "raster") != NULL) ||
+             strcasestr(printer->cmd, "urf") != NULL)
+          printer->appleraster = 1;
     }
     else if(!strcasecmp(attr_name, "printer-uuid"))
        printer->uuid = strdup(buffer + 9);

--- a/src/capabilities.h
+++ b/src/capabilities.h
@@ -30,6 +30,7 @@ typedef struct {
   char *mdl;
   char *mfg;
   char *cmd;
+  int appleraster;
 } ippPrinter;
 
 int is_scanner_present(ippScanner *scanner, int port);

--- a/src/dnssd.c
+++ b/src/dnssd.c
@@ -326,7 +326,7 @@ void * dnssd_escl_register(void *data)
         (g_options.interface ? (int)if_nametoindex(g_options.interface)
         : AVAHI_IF_UNSPEC),
         AVAHI_PROTO_UNSPEC, 0, g_options.dnssd_data->dnssd_name, "_ipp._tcp", NULL,
-        "_print._sub._ipp._tcp");
+        printer->appleraster ? "_universal._sub._ipp._tcp" : "_print._sub._ipp._tcp");
     if (error)
       ERR("Error registering subtype for IPP printer %s (_print._sub._ipp._tcp "
           "or _universal._sub._ipp._tcp): %d",


### PR DESCRIPTION
Restoration of original behaviour :
if appleraster is true then "_universal._sub._ipp._tcp" :is used
otherwise "_print._sub._ipp._tcp" is used.